### PR TITLE
Fix GitHub action that checks for code difference between library and notebooks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         if [ -n "$(git status -uno -s)" ]; then echo -e "!!! Detected unstripped out notebooks\n!!!Remember to run nbdev_install_git_hooks"; false; fi
     - name: Check if there is no diff library/notebooks
       run: |
-        if [-n "$(nbdev_diff_nbs)"]; then echo -e "!!! Detected difference between the notebooks and the library"; false; fi
+        if [ -n "$(nbdev_diff_nbs)" ]; then echo -e "!!! Detected difference between the notebooks and the library"; false; fi
     - name: Run tests
       run: |
         nbdev_test_nbs


### PR DESCRIPTION
This fixes a small issue present in the Github Actions during the 'Check if there is no diff library/notebooks' step. There was some space missing in the shell command, causing it to silently fail and give a false positive result.

![image](https://user-images.githubusercontent.com/20324250/70960034-9d846100-205c-11ea-912f-1cf765aa654e.png)

As far as I have checked, other repositories that use these same actions are affected by this issue as well.

