### PR TITLE
Update setup.py for the latest setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
-from packaging.version import parse
+from pkg_resources import parse_version
 from configparser import ConfigParser
 import setuptools
-assert parse(setuptools.__version__)>=parse('36.2')
+assert parse_version(setuptools.__version__)>=parse_version('41.2')
 
 # note: all settings are in settings.ini; edit there, not here
 config = ConfigParser(delimiters=['='])

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from pkg_resources import parse_version
 from configparser import ConfigParser
 import setuptools
-assert parse_version(setuptools.__version__)>=parse_version('41.2')
+assert parse_version(setuptools.__version__)>=parse_version('36.2')
 
 # note: all settings are in settings.ini; edit there, not here
 config = ConfigParser(delimiters=['='])


### PR DESCRIPTION
With the latest setuptools the `packaging` module does not exist anymore. I have found `parse_version` in the `pkg_resources` module and changed the code accordingly. I know the change is present from the version 41.2, so that is the requirement I've included.