### PR TITLE
Add monospace_docstrings parameter to settings.ini

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -33,6 +33,8 @@ lib_path = %(lib_name)s
 title = %(lib_name)s
 
 #Optional advanced parameters
+#Monospace docstings: adds <pre> tags around the doc strings, preserving newlines/indentation.
+#monospace_docstrings = False
 #Test flags: indtroduce here the test flags you want to use separated by |
 #tst_flags = 
 #Custom sidebar: customize sidebar.json yourself for advanced sidebars (False/True)


### PR DESCRIPTION
Add `monospace_docstrings` as an advanced parameter in settings.ini.