### PR TITLE
change tree to blob

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -53,9 +53,9 @@ doc_baseurl = /%(lib_name)s/
 # For Enterprise Github pages docs use:
 # doc_baseurl = /%(repo_name)s/%(lib_name)s/
 
-git_url = https://github.com/%(user)s/%(lib_name)s/tree/%(branch)s/
+git_url = https://github.com/%(user)s/%(lib_name)s/blob/%(branch)s/
 # For Enterprise Github use:
-#git_url = https://github.%(company_name)s.com/%(repo_name)s/%(lib_name)s/tree/%(branch)s/
+#git_url = https://github.%(company_name)s.com/%(repo_name)s/%(lib_name)s/blob/%(branch)s/
 
 
 


### PR DESCRIPTION
This helps fix #36 
Clicking on the source code in the documentation website causes 404 error