### PR TITLE
[cicd] gitlab support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,21 @@
+image: "python:3.8"
+
+
+tests:
+    tags:
+        - docker
+    script:
+        - |
+            pip install nbdev jupyter
+            pip install -e .
+            nbdev_read_nbs
+            echo "Check we are starting with clean git checkout"
+            if [ -n "$(git status -uno -s)" ]; then echo "git status is not clean"; false; fi
+            echo "Trying to strip out notebooks"
+            nbdev_clean_nbs
+            echo "Check that strip out was unnecessary"
+            git status -s # display the status to see which nbs need cleaning up
+            if [ -n "$(git status -uno -s)" ]; then echo -e "!!! Detected unstripped out notebooks\n!!!Remember to run nbdev_install_git_hooks"; false; fi
+            if [ -n "$(nbdev_diff_nbs)" ]; then echo -e "!!! Detected difference between the notebooks and the library"; false; fi
+            nbdev_test_nbs
+


### PR DESCRIPTION
As an `nbdev_template` user, I would like to have support for GitLab CI out of the box.

### Proposed change

Mirrors the GitHub action checks for a GitLab system.

### GitLab CI/CD assumptions
GitLab runner contains a tag `docker` and runs within a docker container, see [here](https://docs.gitlab.com/runner/install/docker.html).