### PR TITLE
setup.py : Clarify the encoding when reading a file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ assert parse_version(setuptools.__version__)>=parse_version('36.2')
 
 # note: all settings are in settings.ini; edit there, not here
 config = ConfigParser(delimiters=['='])
-config.read('settings.ini')
+config.read('settings.ini', encoding='utf-8')
 cfg = config['DEFAULT']
 
 cfg_keys = 'version description keywords author author_email'.split()
@@ -36,7 +36,7 @@ if cfg.get('requirements'): requirements += cfg.get('requirements','').split()
 if cfg.get('pip_requirements'): requirements += cfg.get('pip_requirements','').split()
 dev_requirements = (cfg.get('dev_requirements') or '').split()
 
-long_description = open('README.md').read()
+long_description = open('README.md', encoding="utf-8").read()
 # ![png](docs/images/output_13_0.png)
 for ext in ['png', 'svg']:
     long_description = re.sub(r'!\['+ext+'\]\((.*)\)', '!['+ext+']('+'https://raw.githubusercontent.com/{}/{}'.format(cfg['user'],cfg['lib_name'])+'/'+cfg['branch']+'/\\1)', long_description)


### PR DESCRIPTION
# Environment
Windows 10 Pro

# Problem
When I tried to `pip install`  the package I created, the following encoding error occured.

## Error Message
(Partially abbreviated in `...`)
```
>pip install git+(my library)
Collecting git+(my library)
  Cloning ...
  Running command git clone ...
  Resolved ...
    ERROR: Command errored out with exit status 1:
     command: '...\Scripts\python.exe' -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\...\\pip-req-build-wpi8iw78\\setup.py'"'"'; ...
         cwd: C:\...
    Complete output (9 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "...\AppData\Local\Temp\pip-req-build-wpi8iw78\setup.py", line 14, in <module>
        config.read('settings.ini')
      File "...\AppData\Local\Programs\Python\Python39\lib\configparser.py", line 697, in read
        self._read(fp, filename)
      File "...\AppData\Local\Programs\Python\Python39\lib\configparser.py", line 1020, in _read
        for lineno, line in enumerate(fp, start=1):
    UnicodeDecodeError: 'cp932' codec can't decode byte 0xef in position 250: illegal multibyte sequence
    ----------------------------------------
WARNING: Discarding git+(my library). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.

```

# Cause
Because the standard input / output of Windows is CP 932, the error occurred while reading a UTF-8 file.

# Fixes
Because `README.md` and `settings.ini` are in UTF-8 encoding, clarified the encoding when reading the file.
